### PR TITLE
Fixed vim mode in the editor

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "next build",
     "clean": "rm -rf .next dist node_modules",
-    "dev": "dotenv -e ../../.env next dev",
+    "dev": "dotenv -e ../../.env next dev -p 3001",
     "format": "prettier -w \"src/**/*.{ts,tsx,css,cjs,mjs,json}\"",
     "lint": "eslint .",
     "start": "next start",

--- a/apps/web/src/components/user/profile.tsx
+++ b/apps/web/src/components/user/profile.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 
 export async function Profile({ username: usernameFromQuery }: Props) {
   const [, username] = decodeURIComponent(usernameFromQuery).split('@');
-  
+
   if (!username) return notFound();
 
   const user = await prisma.user.findFirst({

--- a/apps/web/src/components/wizard/TestCasesEditor.tsx
+++ b/apps/web/src/components/wizard/TestCasesEditor.tsx
@@ -2,9 +2,16 @@ import type { OnChange } from '@monaco-editor/react';
 import type { TsErrors } from '@repo/monaco';
 import { CodeEditor, loadCheckingLib, type CodeEditorProps } from '@repo/monaco/code-editor';
 import { FormField, FormItem, FormMessage, TypographyH3 } from '@repo/ui';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
+import type * as monaco from 'monaco-editor';
+import dynamic from 'next/dynamic';
+import { createTwoslashInlayProvider } from '@repo/monaco/twoslash';
 import type { WizardForm } from '.';
 import { SettingsButton } from '~/app/challenge/_components/settings/settings-button';
+
+const VimStatusBar = dynamic(() => import('@repo/monaco/vim-mode').then((v) => v.VimStatusBar), {
+  ssr: false,
+});
 
 interface Props {
   form: Pick<WizardForm, 'control'>;
@@ -13,40 +20,48 @@ interface Props {
 }
 
 export function TestCasesEditor({ form, hasTsErrors, setTsErrors }: Props) {
-  const onMount = useCallback(
-    (onError: (v: TsErrors) => void): CodeEditorProps['onMount'] =>
-      async (editor, monaco) => {
-        loadCheckingLib(monaco);
+  const [editorState, setEditorState] = useState<monaco.editor.IStandaloneCodeEditor>();
 
-        const model = editor.getModel();
+  const onMount = useCallback<NonNullable<CodeEditorProps['onMount']>>(
+    async (editor, monaco) => {
+      loadCheckingLib(monaco);
 
-        if (!model) {
-          throw new Error();
-        }
+      const model = editor.getModel();
 
-        const ts = await (await monaco.languages.typescript.getTypeScriptWorker())(model.uri);
+      if (!model) {
+        throw new Error();
+      }
 
-        const filename = model.uri.toString();
+      const ts = await (await monaco.languages.typescript.getTypeScriptWorker())(model.uri);
 
-        // what actually runs when checking errors
-        const typeCheck = async () => {
-          const errors = await Promise.all([
-            ts.getSemanticDiagnostics(filename),
-            ts.getSyntacticDiagnostics(filename),
-            ts.getSuggestionDiagnostics(filename),
-            ts.getCompilerOptionsDiagnostics(filename),
-          ] as const);
+      const filename = model.uri.toString();
 
-          onError(errors);
-        };
+      // what actually runs when checking errors
+      const typeCheck = async () => {
+        const errors = await Promise.all([
+          ts.getSemanticDiagnostics(filename),
+          ts.getSyntacticDiagnostics(filename),
+          ts.getSuggestionDiagnostics(filename),
+          ts.getCompilerOptionsDiagnostics(filename),
+        ] as const);
 
-        model.onDidChangeContent(() => {
-          typeCheck().catch(console.error);
-        });
+        setTsErrors(errors);
+      };
 
-        await typeCheck();
-      },
-    [],
+      model.onDidChangeContent(() => {
+        typeCheck().catch(console.error);
+      });
+
+      await typeCheck();
+
+      monaco.languages.registerInlayHintsProvider(
+        'typescript',
+        createTwoslashInlayProvider(monaco, ts),
+      );
+
+      setEditorState(editor);
+    },
+    [setTsErrors],
   );
 
   return (
@@ -57,7 +72,7 @@ export function TestCasesEditor({ form, hasTsErrors, setTsErrors }: Props) {
         name="tests"
         render={({ field }) => {
           return (
-            <FormItem className="h-full">
+            <FormItem className="flex-1">
               <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-zinc-300 dark:border-zinc-700">
                 <div className="sticky top-0 flex h-[40px] flex-row-reverse items-center border-b border-zinc-300 px-3 py-2 dark:border-zinc-700 dark:bg-[#1e1e1e]">
                   <SettingsButton />
@@ -65,9 +80,12 @@ export function TestCasesEditor({ form, hasTsErrors, setTsErrors }: Props) {
                 <div className="w-full flex-1">
                   <CodeEditor
                     onChange={field.onChange as OnChange}
-                    onMount={onMount(setTsErrors)}
+                    onMount={onMount}
                     value={field.value}
                   />
+                </div>
+                <div className="sticky bottom-0 flex items-center justify-end p-2 dark:bg-[#1e1e1e]">
+                  {editorState ? <VimStatusBar editor={editorState} /> : null}
                 </div>
                 <FormMessage />
                 {!hasTsErrors && (

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -5,7 +5,9 @@
   "exports": {
     ".": "./src/index.tsx",
     "./code-editor": "./src/code-editor.tsx",
-    "./settings-store": "./src/settings-store.ts"
+    "./settings-store": "./src/settings-store.ts",
+    "./vim-mode": "./src/vim-mode.tsx",
+    "./twoslash": "./src/twoslash.ts"
   },
   "typesVersions": {
     "*": {
@@ -17,6 +19,12 @@
       ],
       "settings-store": [
         "./src/settings-store.ts"
+      ],
+      "vim-mode": [
+        "./src/vim-mode.tsx"
+      ],
+      "twoslash": [
+        "./src/twoslash.ts"
       ]
     }
   },

--- a/packages/monaco/src/code-editor.tsx
+++ b/packages/monaco/src/code-editor.tsx
@@ -31,7 +31,7 @@ const DEFAULT_OPTIONS = {
   fontSize: 16,
 } as const satisfies EditorProps['options'];
 
-export const LIB_URI = 'ts:filename/checking.d.ts';
+export const LIB_URI = 'file:///asserts.d.ts';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export function loadCheckingLib(monaco: typeof import('monaco-editor')) {
   if (!monaco.editor.getModel(monaco.Uri.parse(LIB_URI))) {

--- a/packages/monaco/src/twoslash.ts
+++ b/packages/monaco/src/twoslash.ts
@@ -1,14 +1,18 @@
 // based on: https://github.com/microsoft/TypeScript-Website/blob/v2/packages/playground/src/twoslashInlays.ts
 import type * as monaco from 'monaco-editor';
 
+export const TWOSLASH_INLAY_HINTS_PROVIDER = 'twoslash inlay hints provider';
+const queryRegex = /^\s*\/\/\s*\^\?$/gm;
+
 export const createTwoslashInlayProvider = (
   m: typeof monaco,
   worker: monaco.languages.typescript.TypeScriptWorker,
 ) => {
   const provider: monaco.languages.InlayHintsProvider = {
+    displayName: TWOSLASH_INLAY_HINTS_PROVIDER,
     provideInlayHints: async (model, _, cancel) => {
       const text = model.getValue();
-      const queryRegex = /^\s*\/\/\s*\^\?$/gm;
+
       let match;
       const results: monaco.languages.InlayHint[] = [];
       if (model.isDisposed()) {

--- a/packages/monaco/src/vim-mode.tsx
+++ b/packages/monaco/src/vim-mode.tsx
@@ -6,7 +6,7 @@ import { type VimMode, initVimMode } from 'monaco-vim';
 import { useEditorSettingsStore } from './settings-store';
 
 interface VimStatusBarProps {
-	editor: monaco.editor.IStandaloneCodeEditor;
+  editor: monaco.editor.IStandaloneCodeEditor;
 }
 
 export function VimStatusBar({ editor }: VimStatusBarProps) {
@@ -16,15 +16,16 @@ export function VimStatusBar({ editor }: VimStatusBarProps) {
 
   useEffect(() => {
     if (settings.bindings === 'vim') {
-      if (!vimModeRef.current) {
-        vimModeRef.current = initVimMode(editor, statusBarRef.current);
-      }
-    } else {
-      vimModeRef.current?.dispose();
-      vimModeRef.current = undefined;
-      if (statusBarRef.current) {
-        statusBarRef.current.textContent = '';
-      }
+      vimModeRef.current = initVimMode(editor, statusBarRef.current);
+
+      return () => vimModeRef.current?.dispose();
+    }
+
+    vimModeRef.current?.dispose();
+    vimModeRef.current = undefined;
+
+    if (statusBarRef.current) {
+      statusBarRef.current.textContent = '';
     }
   }, [editor, settings.bindings]);
 


### PR DESCRIPTION
Closes #397 

Changes:
- Fixed vim to work with the split editor
- Removed some of the code that wasn't being used anymore
- Added vim mode to the challenge creation pane

Further changes:
- Map `K` to hover in vim mode
- maybe reuse the code panel for the challenge creation?