### PR TITLE
[POC] feat: GitLab auth PoC

### DIFF
--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -23,6 +23,8 @@ export function Navigation() {
   const pathname = usePathname();
   const featureFlags = useContext(FeatureFlagContext);
 
+  console.info(featureFlags);
+
   return (
     <header className="z-10 w-full">
       <nav
@@ -77,7 +79,7 @@ export function Navigation() {
           <div className="flex">
             <div className="flex items-center justify-end gap-2">
               <ThemeButton />
-              {featureFlags?.loginButton ? <LoginButton /> : null}
+              {true ? <LoginButton /> : null}
             </div>
           </div>
         </div>
@@ -125,7 +127,7 @@ function LoginButton() {
     try {
       setLoading(true);
       // page reloads after sign in, so no need to setLoading(false), othersiwe ugly visual glitch
-      await signIn('github', { redirect: false });
+      await signIn('gitlab|github', { redirect: false });
     } catch (error) {
       // only set loading to false if there was an error and page didn't reload after sign in
       setLoading(false);

--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -127,7 +127,7 @@ function LoginButton() {
     try {
       setLoading(true);
       // page reloads after sign in, so no need to setLoading(false), othersiwe ugly visual glitch
-      await signIn('gitlab|github', { redirect: false });
+      await signIn('gitlab|github|discord', { redirect: false });
     } catch (error) {
       // only set loading to false if there was an error and page didn't reload after sign in
       setLoading(false);

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -3,6 +3,7 @@ import type { Role, RoleTypes } from '@repo/db/types';
 import { getServerSession, type DefaultSession, type NextAuthOptions } from 'next-auth';
 import GitHubProvider from 'next-auth/providers/github';
 import GitlabProvider from 'next-auth/providers/gitlab';
+import DiscordProvider from 'next-auth/providers/discord';
 import { prisma } from '@repo/db';
 
 export type { Session, DefaultSession as DefaultAuthSession } from 'next-auth';
@@ -117,6 +118,10 @@ export const authOptions: NextAuthOptions = {
     GitlabProvider({
       clientId: process.env.GITLAB_ID!,
       clientSecret: process.env.GITLAB_SECRET!,
+    }),
+    DiscordProvider({
+      clientId: process.env.DISCORD_ID!,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET!
     })
   ],
 };

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -2,6 +2,7 @@ import { PrismaAdapter } from '@next-auth/prisma-adapter';
 import type { Role, RoleTypes } from '@repo/db/types';
 import { getServerSession, type DefaultSession, type NextAuthOptions } from 'next-auth';
 import GitHubProvider from 'next-auth/providers/github';
+import GitlabProvider from 'next-auth/providers/gitlab';
 import { prisma } from '@repo/db';
 
 export type { Session, DefaultSession as DefaultAuthSession } from 'next-auth';
@@ -113,6 +114,10 @@ export const authOptions: NextAuthOptions = {
       clientId: process.env.GITHUB_ID!,
       clientSecret: process.env.GITHUB_SECRET!,
     }),
+    GitlabProvider({
+      clientId: process.env.GITLAB_ID!,
+      clientSecret: process.env.GITLAB_SECRET!,
+    })
   ],
 };
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -121,7 +121,7 @@ export const authOptions: NextAuthOptions = {
     }),
     DiscordProvider({
       clientId: process.env.DISCORD_ID!,
-      clientSecret: process.env.DISCORD_CLIENT_SECRET!
+      clientSecret: process.env.DISCORD_CLIENT_SECRET!,
     })
   ],
 };

--- a/packages/db/schema.prisma
+++ b/packages/db/schema.prisma
@@ -63,6 +63,7 @@ model Account {
   scope             String?
   id_token          String? // @db.Text
   session_state     String?
+  created_at        Int?
   user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])


### PR DESCRIPTION
## Description

Added in some rough testing for GitLab OAuth flow.

## Notes

The Gitlab user comes back with a `created_at` which is an integer, so I had to add that.

Whether or not we want to do that we can.

Some other limitations: you cannot have more than 1 oauth source that share the same email, and from what I've read in next auth there is no work around because that was a decision by the next auth team.