### PR TITLE
ci: fix formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 # need to be given their own .prettierignore in their workspace.
 
 .env
+.next
 .github
 node_modules
 *.log

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <br />
 
 ![typehero header](./media/header.png)
+
 ### About Us
 
 TypeScript's typing system can be very powerful when used correctly. The problem
@@ -22,8 +23,10 @@ the intricacies of TypeScript's typing system.
 Please see the [`LOCAL.md`](/LOCAL.md) on how to get setup. Consider joining the [discord](https://discord.gg/trashdev) if you have any ideas/feedback. We'd love to hear from you!
 
 ### Sponsors
+
 If you find the project interesting and want to support us please consider sponsoring. Your sponsorship would not only contribute to the advancement of this project but also ensure its ongoing maintenance and improvement for the benefit of the open-source community.
 <a href="https://vercel.com/?utm_source=trash-company&utm_campaign=oss">
+
   <p>
     <img src="https://images.ctfassets.net/e5382hct74si/78Olo8EZRdUlcDUFQvnzG7/fa4cdb6dc04c40fceac194134788a0e2/1618983297-powered-by-vercel.svg" alt="Powered by Vercel" title="Powered by Vercel">
   </p>


### PR DESCRIPTION
- Run `format:fix` to format the README that had errors (https://github.com/bautistaaa/typehero/actions/runs/5979181595/job/16222741772#step:4:84)
- Ignore `.next` to not be formatted by Prettier