### PR TITLE
feat: add more vim keybindings to editor

### DIFF
--- a/packages/monaco/src/vim-keybindings.ts
+++ b/packages/monaco/src/vim-keybindings.ts
@@ -1,0 +1,54 @@
+import { VimMode } from 'monaco-vim';
+
+type Keybind = {
+  key: string;
+  action: string;
+  name: string;
+};
+
+function registerKeybind({ key, action, name }: Keybind) {
+  VimMode.Vim.defineAction(name, function (ctx) {
+    ctx.editor.trigger('action', action, null);
+  });
+  VimMode.Vim.mapCommand(key, 'action', name);
+}
+
+const KEYBINDS: Keybind[] = [
+  {
+    key: 'K',
+    action: 'editor.action.showHover',
+    name: 'hover',
+  },
+  {
+    key: 'gd',
+    action: 'editor.action.goToDeclaration',
+    name: 'goToDeclaration',
+  },
+  {
+    key: 'gr',
+    action: 'editor.action.goToReferences',
+    name: 'goToReferences',
+  },
+  {
+    key: 'gi',
+    action: 'editor.action.goToImplementation',
+    name: 'goToImplementation',
+  },
+  {
+    key: 'gx',
+    action: 'editor.action.openLink',
+    name: 'goToLink',
+  },
+  {
+    key: ']d',
+    action: 'editor.action.marker.next',
+    name: 'nextDiagnostic',
+  },
+  {
+    key: '[d',
+    action: 'editor.action.marker.prev',
+    name: 'prevDiagnostic',
+  },
+];
+
+KEYBINDS.forEach(registerKeybind);

--- a/packages/monaco/src/vim-mode.tsx
+++ b/packages/monaco/src/vim-mode.tsx
@@ -4,17 +4,11 @@ import type * as monaco from 'monaco-editor';
 import { useEffect, useRef } from 'react';
 import { VimMode, initVimMode } from 'monaco-vim';
 import { useEditorSettingsStore } from './settings-store';
+import './vim-keybindings';
 
 interface VimStatusBarProps {
   editor: monaco.editor.IStandaloneCodeEditor;
 }
-
-// `K` -> hover
-VimMode.Vim.defineAction('hover', function (ctx) {
-  // it didn't work without the set timeout, it probably handles the key after and dismisses it
-  setTimeout(() => ctx.editor.getAction('editor.action.showHover')?.run());
-});
-VimMode.Vim.mapCommand('K', 'action', 'hover');
 
 export function VimStatusBar({ editor }: VimStatusBarProps) {
   const statusBarRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
Added more vim keybinds related to #399 

Go to references is a bit odd because it opens a preview window that makes you put your hand back on the mouse :sweat_smile: 