### PR TITLE
Correct pink-30 to pink-300

### DIFF
--- a/apps/web/src/components/landing/feature-card.tsx
+++ b/apps/web/src/components/landing/feature-card.tsx
@@ -479,7 +479,7 @@ const COLORS_BY_DIFFICULTY = {
 };
 
 const BGS_BY_DIFFICULTY = {
-  BEGINNER: 'to-pink-600/20 dark:to-pink-30/20',
+  BEGINNER: 'to-pink-600/20 dark:to-pink-300/20',
   EASY: 'to-emerald-600/20 dark:to-emerald-300/20',
   MEDIUM: 'to-yellow-600/20 dark:to-yellow-300/20',
   HARD: 'to-red-600/20 dark:to-red-300/20',


### PR DESCRIPTION
This PR corrects a typo and will update the background of the difficulty item in the feature card to be `pink-300` and not `pink-30`.