### PR TITLE
ci: add automatic contributors list update

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -3,8 +3,6 @@ name: Contributors
 on:
   schedule:
     - cron: '0 0 * * *'
-  # TODO: remove pull_request even before merging
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -18,6 +18,9 @@ jobs:
     name: Update
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -34,5 +34,6 @@ jobs:
           commit-message: 'chore: update contributors'
           title: 'chore: update contributors'
           branch: chore/update-contributors
+          base: main
           delete-branch: true
 

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,38 @@
+name: Contributors
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  # TODO: remove pull_request even before merging
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  update:
+    name: Update
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install
+        uses: ./tooling/github-actions/install
+
+      - name: Run contributors script
+        run: turbo dl-git
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'chore: update contributors'
+          title: 'chore: update contributors'
+          branch: chore/update-contributors
+          delete-branch: true
+


### PR DESCRIPTION
Run the `dl-git` script every 24 hours and create/update a PR to automatically update the contributors list.

To test on a PR we'll need a personal access token (see https://github.com/marketplace/actions/create-pull-request#action-inputs):
![Screenshot 2023-08-26 at 08 55 43](https://github.com/bautistaaa/typehero/assets/43268759/ad207061-4cff-4be5-9174-b0fdea3bad23)
