### PR TITLE
Fix: light mode waitlist banner

### DIFF
--- a/apps/web/src/components/landing/waitlist/waitlist-form.tsx
+++ b/apps/web/src/components/landing/waitlist/waitlist-form.tsx
@@ -179,7 +179,7 @@ export function AlertSuccess() {
   return (
     <Alert variant="success">
       <MailCheck className="h-4 w-4" />
-      <AlertDescription className="text-left text-black dark:text-white">
+      <AlertDescription className="text-left text-white">
         Thanks for signing up for the waitlist! Consider{' '}
         <a
           className="underline"


### PR DESCRIPTION
This PR solves https://github.com/bautistaaa/typehero/issues/441 by keeping text white across light/dark mode on waitlist-form alert success.

Updated light-mode version (note: dark mode stays the same as before):

<img width="1439" alt="image" src="https://github.com/bautistaaa/typehero/assets/44373521/8fd44d99-1f5b-47d5-8121-f2745fc3e99e">
