### PR TITLE
feat: use `next/image` for contributors avatars

### DIFF
--- a/apps/web/src/components/landing/community/community.tsx
+++ b/apps/web/src/components/landing/community/community.tsx
@@ -6,6 +6,7 @@ import { type CSSProperties } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { contributors } from '../../../../public/contributors';
 import styles from '~/components/landing/community/community.module.css';
+import Image from 'next/image';
 
 function Community() {
   type WrapperStyle = CSSProperties & {
@@ -104,9 +105,11 @@ function Community() {
                     rel="noopener"
                     target="_blank"
                   >
-                    <div
-                      className="honeycombchild h-16 w-16 rounded-3xl bg-cover duration-300 group-hover:rounded-[2rem] group-active:rounded-3xl group-active:duration-100"
-                      style={{ backgroundImage: `url('${contributor.avatar_url}')` }}
+                    <Image
+                      className="honeycombchild h-16 w-16 rounded-3xl bg-cover duration-300 group-hover:rounded-[2rem] group-active:rounded-3xl group-active:duration-100" src={contributor.avatar_url}
+                      width={64}
+                      height={64}
+                      alt={`${contributor.login}'s avatar`}
                     />
                   </a>
                 ))}

--- a/apps/web/src/components/landing/community/community.tsx
+++ b/apps/web/src/components/landing/community/community.tsx
@@ -106,10 +106,11 @@ function Community() {
                     target="_blank"
                   >
                     <Image
-                      className="honeycombchild h-16 w-16 rounded-3xl bg-cover duration-300 group-hover:rounded-[2rem] group-active:rounded-3xl group-active:duration-100" src={contributor.avatar_url}
+                      className="honeycombchild h-16 w-16 rounded-3xl bg-cover duration-300 group-hover:rounded-[2rem] group-active:rounded-3xl group-active:duration-100"
+                      src={contributor.avatar_url}
                       width={64}
                       height={64}
-                      alt={`${contributor.login}'s avatar`}
+                      alt={`${contributor.login}'s GitHub avatar`}
                     />
                   </a>
                 ))}


### PR DESCRIPTION
We were using a `div` with a `backgroundImage`, which causes big payloads and unnecessary network requests when not in the viewport:

![Screenshot 2023-08-27 at 17 39 44](https://github.com/bautistaaa/typehero/assets/43268759/556b904d-ac66-4eb4-a416-8949c1a5d590)
