### PR TITLE
[479] Bugfix :: Dialog box :: Aligned close icon with title

### DIFF
--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -49,7 +49,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       {displayX ? (
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-6 top-6 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>


### PR DESCRIPTION
This PR addresses https://github.com/bautistaaa/typehero/issues/479
Fixed position of close icon
![image](https://github.com/bautistaaa/typehero/assets/72158561/fb252c47-6198-48b7-9f93-aa42310724b1)
