### PR TITLE
feat(web): highlight current path (explore, tracks)

### DIFF
--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@repo/ui';
 import { Loader2, LogIn, Moon, Plus, Settings, Settings2, Sun, User } from '@repo/ui/icons';
+import clsx from 'clsx';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -80,14 +81,22 @@ export function Navigation() {
             </a>
             {featureFlags?.exploreButton ? (
               <Link href="/explore" className="ml-4">
-                <div className="hover:text-foreground text-foreground/80 transition-colors">
+                <div
+                  className={clsx('hover:text-foreground text-foreground/80 transition-colors', {
+                    '!text-foreground': pathname === '/explore',
+                  })}
+                >
                   Explore
                 </div>
               </Link>
             ) : null}
             {featureFlags?.tracksButton ? (
               <Link href="/tracks" className="ml-4">
-                <div className="hover:text-foreground text-foreground/80 transition-colors">
+                <div
+                  className={clsx('hover:text-foreground text-foreground/80 transition-colors', {
+                    '!text-foreground': pathname === '/tracks',
+                  })}
+                >
                   Tracks
                 </div>
               </Link>


### PR DESCRIPTION
Another very small PR to highlight the current URL in the nav:

Home:
![Screenshot 2023-08-29 at 18 15 50](https://github.com/bautistaaa/typehero/assets/43268759/39e34b30-8cdb-4de7-a68f-bbdcba1f375e)

Explore:
![Screenshot 2023-08-29 at 18 14 16](https://github.com/bautistaaa/typehero/assets/43268759/b9e3542b-7f11-49a0-91f5-b2be66a44394)

Tracks:
![Screenshot 2023-08-29 at 18 14 13](https://github.com/bautistaaa/typehero/assets/43268759/e109370e-ed3c-4f1b-9776-5b4c92b2de70)