### PR TITLE
Fix: improve accessibility on landing (color/aria-labels)

### DIFF
--- a/apps/admin/src/components/navigation.tsx
+++ b/apps/admin/src/components/navigation.tsx
@@ -73,6 +73,7 @@ function ThemeButton() {
     <>
       {mounted ? (
         <button
+          aria-label="theme button"
           className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none"
           onClick={() => {
             setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
@@ -115,7 +116,7 @@ function LoginButton() {
   return session ? (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none">
+        <button aria-label="profile button" className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none">
           <User className="h-5 w-5" />
         </button>
       </DropdownMenuTrigger>

--- a/apps/admin/src/components/navigation.tsx
+++ b/apps/admin/src/components/navigation.tsx
@@ -116,7 +116,10 @@ function LoginButton() {
   return session ? (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button aria-label="profile button" className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none">
+        <button
+          aria-label="profile button"
+          className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none"
+        >
           <User className="h-5 w-5" />
         </button>
       </DropdownMenuTrigger>

--- a/apps/web/src/app/_components/hero.tsx
+++ b/apps/web/src/app/_components/hero.tsx
@@ -47,7 +47,7 @@ function Hero() {
             </h1>
           </div>
 
-          <p className="max-w-[55ch] bg-transparent px-8 text-center font-medium leading-8 text-black/50 dark:text-white/50 lg:px-0 lg:text-left">
+          <p className="max-w-[55ch] bg-transparent px-8 text-center font-medium leading-8 text-black/60 dark:text-white/50 lg:px-0 lg:text-left">
             <Balancer>
               Connect, collaborate, and grow with a community of TypeScript developers. Elevate your
               skills through interactive coding challenges, discussions, and knowledge sharing

--- a/apps/web/src/components/ui/footsies.tsx
+++ b/apps/web/src/components/ui/footsies.tsx
@@ -8,7 +8,9 @@ export function Footsies() {
           Built with <Binary className="inline-block h-5 w-5 text-[#31bdc6]" /> by the Trash Devs
           community.
         </div>
-        <div className="dark:text-neutral-400 text-neutral-500">© {new Date().getFullYear()} Type Hero</div>
+        <div className="text-neutral-500 dark:text-neutral-400">
+          © {new Date().getFullYear()} Type Hero
+        </div>
       </div>
     </footer>
   );

--- a/apps/web/src/components/ui/footsies.tsx
+++ b/apps/web/src/components/ui/footsies.tsx
@@ -8,7 +8,7 @@ export function Footsies() {
           Built with <Binary className="inline-block h-5 w-5 text-[#31bdc6]" /> by the Trash Devs
           community.
         </div>
-        <div className="text-neutral-500">© {new Date().getFullYear()} Type Hero</div>
+        <div className="dark:text-neutral-400 text-neutral-500">© {new Date().getFullYear()} Type Hero</div>
       </div>
     </footer>
   );

--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -173,7 +173,10 @@ function LoginButton() {
   return session ? (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button aria-label="profile button" className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none focus-visible:ring-2">
+        <button
+          aria-label="profile button"
+          className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none focus-visible:ring-2"
+        >
           <User className="h-5 w-5" />
         </button>
       </DropdownMenuTrigger>

--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -130,6 +130,7 @@ function ThemeButton() {
     <>
       {mounted ? (
         <button
+          aria-label="light/dark button"
           className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none focus-visible:ring-2"
           onClick={() => {
             setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
@@ -172,7 +173,7 @@ function LoginButton() {
   return session ? (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none focus-visible:ring-2">
+        <button aria-label="profile button" className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none focus-visible:ring-2">
           <User className="h-5 w-5" />
         </button>
       </DropdownMenuTrigger>

--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -130,7 +130,7 @@ function ThemeButton() {
     <>
       {mounted ? (
         <button
-          aria-label="light/dark button"
+          aria-label="theme button"
           className="focus:bg-accent rounded-lg p-2 duration-300 focus:outline-none focus-visible:ring-2"
           onClick={() => {
             setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');


### PR DESCRIPTION
This adds slightly higher contrast to the footer, landing description, and aria labels to our buttons in the navigation 👍🏻

(Note: performance is low only due to me being on dev server on local)
<img width="1351" alt="image" src="https://github.com/bautistaaa/typehero/assets/44373521/c5e30656-fdab-4401-ad25-de265dc6ce5f">

